### PR TITLE
[fix](vis) Añadida alerta de activación/desactivación y errores de adaptación corregidos

### DIFF
--- a/decide/visualizer/templates/visualizer/visualizer.html
+++ b/decide/visualizer/templates/visualizer/visualizer.html
@@ -598,11 +598,11 @@
          }
 
          function deleteAlert(mode) {
-            if(mode=="dark") {
-               document.getElementById("alertDarkMode").remove();
-            } else {
-               document.getElementById("alertDarkModeDes").remove();
-            }
+               if (mode == "dark" && document.contains(document.getElementById("alertDarkMode"))) {
+                  document.getElementById("alertDarkMode").remove();
+               } else if (document.contains(document.getElementById("alertDarkModeDes"))) {
+                  document.getElementById("alertDarkModeDes").remove();
+               }
          }
 
         window.onload = checkCookie();

--- a/decide/visualizer/templates/visualizer/visualizer.html
+++ b/decide/visualizer/templates/visualizer/visualizer.html
@@ -42,6 +42,12 @@
          .bg-dark-mode{
             background-color: #000000;
          }
+         .notification{
+            position:fixed;
+            z-index: 999;
+            top: 1rem;
+            right: 1rem;
+         }
       </style>
 {% endblock %}
 
@@ -549,20 +555,20 @@
                }
                var alertDiv = document.createElement("div");
                alertDiv.setAttribute("id","alertDarkMode");
-		         alertDiv.setAttribute("class","alert alert-success alert-dimissible fade show");
+		         alertDiv.setAttribute("class","alert alert-success alert-dimissible fade show card-shadow-3 w-50 notification");
 		         alertDiv.setAttribute("role","alert");
-		         alertDiv.innerHTML = "Modo oscuro activado";
+		         alertDiv.innerHTML = "Modo oscuro <b>activado</b>";
                var buttonClose = document.createElement("button");
                buttonClose.setAttribute("type", "button");
                buttonClose.setAttribute("class", "close");
-               buttonClose.setAttribute("data-dimiss", "alert");
+               buttonClose.setAttribute("data-dismiss", "alert");
                buttonClose.setAttribute("aria-label", "Close");
                var span = document.createElement("span");
                span.setAttribute("aria-hidden", "true");
                span.innerHTML = "&times;";
                buttonClose.appendChild(span);
                alertDiv.appendChild(buttonClose);
-               document.getElementById('topCard').appendChild(alertDiv);
+               document.body.appendChild(alertDiv);
                setTimeout("deleteAlert('dark')", 8000);
             } else if (mode=="light" && document.body.className == "bg-dark-mode") {
                if (document.contains(document.getElementById("alertDarkModeDes"))) {
@@ -573,20 +579,20 @@
                }
                var alertDiv = document.createElement("div");
                alertDiv.setAttribute("id","alertDarkModeDes");
-		         alertDiv.setAttribute("class","alert alert-success alert-dimissible fade show");
+		         alertDiv.setAttribute("class","alert alert-secondary alert-dimissible fade show card-shadow-3 w-50 notification");
 		         alertDiv.setAttribute("role","alert");
-		         alertDiv.innerHTML = "Modo oscuro desactivado";
+		         alertDiv.innerHTML = "Modo oscuro <b>desactivado</b>";
                var buttonClose = document.createElement("button");
                buttonClose.setAttribute("type", "button");
                buttonClose.setAttribute("class", "close");
-               buttonClose.setAttribute("data-dimiss", "alert");
+               buttonClose.setAttribute("data-dismiss", "alert");
                buttonClose.setAttribute("aria-label", "Close");
                var span = document.createElement("span");
                span.setAttribute("aria-hidden", "true");
                span.innerHTML = "&times;";
                buttonClose.appendChild(span);
                alertDiv.appendChild(buttonClose);
-               document.getElementById('topCard').appendChild(alertDiv);
+               document.body.appendChild(alertDiv);
                setTimeout("deleteAlert('light')", 8000);
             }
          }

--- a/decide/visualizer/templates/visualizer/visualizer.html
+++ b/decide/visualizer/templates/visualizer/visualizer.html
@@ -218,7 +218,7 @@
               <div id="exportDiv" class="modal-content">
                  <div class="modal-header">
                     <h5 class="modal-title" id="exampleModalLabel"><i class="material-icons mr-1">import_export</i> Exportar</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <button id="closeExport" type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                     </button>
                  </div>
@@ -240,7 +240,7 @@
               <div id="shareDiv" class="modal-content">
                  <div class="modal-header">
                     <h5 class="modal-title" id="exampleModalLabel"><i class="material-icons mr-1">share</i> Compartir</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <button id="closeShare" type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                     </button>
                  </div>
@@ -495,6 +495,8 @@
             document.getElementById("dropDownColors3").className = "dropdown-item text-white";
             document.getElementById("dropDownColors4").className = "dropdown-item text-white";
             document.getElementById("dropDownColors5").className = "dropdown-item text-white";
+            document.getElementById("closeExport").className = "close text-white";
+            document.getElementById("closeShare").className = "close text-white";
             setCookie("theme", "dark", 365);
          }
 
@@ -520,6 +522,8 @@
             document.getElementById("dropDownColors3").className = "dropdown-item";
             document.getElementById("dropDownColors4").className = "dropdown-item";
             document.getElementById("dropDownColors5").className = "dropdown-item";
+            document.getElementById("closeExport").className = "close";
+            document.getElementById("closeShare").className = "close";
             setCookie("theme", "light", 365);
          }
 

--- a/decide/visualizer/templates/visualizer/visualizer.html
+++ b/decide/visualizer/templates/visualizer/visualizer.html
@@ -112,8 +112,8 @@
                           Modo oscuro
                           </a>
                           <div id="dropDownDarkMode" class="dropdown-menu card-shadow-3" aria-labelledby="dropdownMenuLink">
-                           <a id="activeDarkModeButton" class="dropdown-item" href="#" onclick="activateDarkMode()">Activado</a>
-                           <a id="activeLightModeButton" class="dropdown-item active" href="#" onclick="activateLightMode()">Desactivado</a>
+                           <a id="activeDarkModeButton" class="dropdown-item" href="#" onclick="alertDarkMode('dark'); activateDarkMode()">Activado</a>
+                           <a id="activeLightModeButton" class="dropdown-item active" href="#" onclick="alertDarkMode('light'); activateLightMode()">Desactivado</a>
                           </div>
                        </div>
                     </li>
@@ -536,6 +536,66 @@
                document.getElementById("activeDarkModeButton").className = "dropdown-item";
                document.getElementById("activeLightModeButton").className = "dropdown-item active";
                document.getElementById("dropDownDarkMode").className = "dropdown-menu card-shadow-3 dropdown";
+            }
+         }
+
+         function alertDarkMode(mode) {
+            if (mode=="dark" && document.body.className == "bg-light") {
+               if (document.contains(document.getElementById("alertDarkModeDes"))) {
+                  document.getElementById("alertDarkModeDes").remove();  
+               }
+               if (document.contains(document.getElementById("alertDarkMode"))) {
+                  document.getElementById("alertDarkMode").remove();  
+               }
+               var alertDiv = document.createElement("div");
+               alertDiv.setAttribute("id","alertDarkMode");
+		         alertDiv.setAttribute("class","alert alert-success alert-dimissible fade show");
+		         alertDiv.setAttribute("role","alert");
+		         alertDiv.innerHTML = "Modo oscuro activado";
+               var buttonClose = document.createElement("button");
+               buttonClose.setAttribute("type", "button");
+               buttonClose.setAttribute("class", "close");
+               buttonClose.setAttribute("data-dimiss", "alert");
+               buttonClose.setAttribute("aria-label", "Close");
+               var span = document.createElement("span");
+               span.setAttribute("aria-hidden", "true");
+               span.innerHTML = "&times;";
+               buttonClose.appendChild(span);
+               alertDiv.appendChild(buttonClose);
+               document.getElementById('topCard').appendChild(alertDiv);
+               setTimeout("deleteAlert('dark')", 8000);
+            } else if (mode=="light" && document.body.className == "bg-dark-mode") {
+               if (document.contains(document.getElementById("alertDarkModeDes"))) {
+                  document.getElementById("alertDarkModeDes").remove();  
+               }
+               if (document.contains(document.getElementById("alertDarkMode"))) {
+                  document.getElementById("alertDarkMode").remove();  
+               }
+               var alertDiv = document.createElement("div");
+               alertDiv.setAttribute("id","alertDarkModeDes");
+		         alertDiv.setAttribute("class","alert alert-success alert-dimissible fade show");
+		         alertDiv.setAttribute("role","alert");
+		         alertDiv.innerHTML = "Modo oscuro desactivado";
+               var buttonClose = document.createElement("button");
+               buttonClose.setAttribute("type", "button");
+               buttonClose.setAttribute("class", "close");
+               buttonClose.setAttribute("data-dimiss", "alert");
+               buttonClose.setAttribute("aria-label", "Close");
+               var span = document.createElement("span");
+               span.setAttribute("aria-hidden", "true");
+               span.innerHTML = "&times;";
+               buttonClose.appendChild(span);
+               alertDiv.appendChild(buttonClose);
+               document.getElementById('topCard').appendChild(alertDiv);
+               setTimeout("deleteAlert('light')", 8000);
+            }
+         }
+
+         function deleteAlert(mode) {
+            if(mode=="dark") {
+               document.getElementById("alertDarkMode").remove();
+            } else {
+               document.getElementById("alertDarkModeDes").remove();
             }
          }
 

--- a/decide/visualizer/templates/visualizer/visualizer.html
+++ b/decide/visualizer/templates/visualizer/visualizer.html
@@ -82,8 +82,8 @@
 
     <main role="main">
         <div class="container mt-4">
-           <div class="card card-shadow-2 bg-white">
-              <div id="topCard" class="card-body text-center">
+           <div id="topCard" class="card card-shadow-2 bg-white">
+              <div class="card-body text-center">
                  <ul class="nav">
                     <li class="nav-item d-flex justify-content-start">
                         <div class="text-info mr-1 pointer" data-container="body" data-toggle="popover" data-placement="bottom" 
@@ -122,32 +122,32 @@
            </div>
            <div class="row">
               <div class="col-sm">
-                 <div class="card card-shadow-2 bg-white mt-4">
-                    <div id="optionsNumberCard" class="card-body">
+                 <div id="optionsNumberCard" class="card card-shadow-2 bg-white mt-4">
+                    <div class="card-body">
                        <h6 class="card-title text-muted" >Nº DE OPCIONES</h6>
                        <h3 class="card-text text-center mb-3">[[ voting.postproc.length ]]</h3>
                     </div>
                  </div>
               </div>
               <div class="col-sm">
-                 <div class="card card-shadow-2 bg-white mt-4">
-                    <div id="votesNumberCard" class="card-body">
+                 <div id="votesNumberCard" class="card card-shadow-2 bg-white mt-4">
+                    <div class="card-body">
                        <h6 class="card-title text-muted">Nº DE VOTOS</h6>
                        <h3 id="total_votes" class="card-text text-center mb-3">0</h3>
                     </div>
                  </div>
               </div>
               <div class="col-sm">
-               <div class="card card-shadow-2 bg-white mt-4">
-                  <div id="beginCard" class="card-body">
+               <div id="beginCard" class="card card-shadow-2 bg-white mt-4">
+                  <div class="card-body">
                    <h6 class="card-title text-muted">COMIENZO</h6>
                    <h3 id="start_date" class="card-text text-center mb-3">DD/MM/YYYY</h3>
                   </div>
                </div>
             </div>
               <div class="col-sm">
-                 <div class="card card-shadow-2 bg-white mt-4">
-                    <div id="finishCard" class="card-body">
+                 <div id="finishCard" class="card card-shadow-2 bg-white mt-4">
+                    <div class="card-body">
                        <h6 class="card-title text-muted">FINALIZACIÓN</h6>
                        <h3 id="end_date" class="card-text text-center mb-3">DD/MM/YYYY</h3>
                     </div>
@@ -476,11 +476,11 @@
          function activateDarkMode() {
             changeSelectorDarkMode("dark");
             document.body.className = "bg-dark-mode";
-            document.getElementById("topCard").className = "bg-dark card-body text-center";
-            document.getElementById("optionsNumberCard").className = "text-white bg-dark card-body";
-            document.getElementById("votesNumberCard").className = "text-white bg-dark card-body";
-            document.getElementById("beginCard").className = "text-white bg-dark card-body";
-            document.getElementById("finishCard").className = "text-white bg-dark card-body";
+            document.getElementById("topCard").className = "card card-shadow-2 bg-dark";
+            document.getElementById("optionsNumberCard").className = "card card-shadow-2 bg-dark text-white mt-4";
+            document.getElementById("votesNumberCard").className = "card card-shadow-2 bg-dark text-white mt-4";
+            document.getElementById("beginCard").className = "card card-shadow-2 bg-dark text-white mt-4";
+            document.getElementById("finishCard").className = "card card-shadow-2 bg-dark text-white mt-4";
             document.getElementById("congressCard").className = "card card-shadow-2 mt-4 text-white bg-dark";
             document.getElementById("footerVis").className = "card card-shadow-2 text-white bg-dark";
             document.getElementById("daltonicButton").className = "btn btn-sm btn-outline-light dropdown-toggle";
@@ -501,11 +501,11 @@
          function activateLightMode() {
             changeSelectorDarkMode("light");
             document.body.className = "bg-light";
-            document.getElementById("topCard").className = "bg-light card-body text-center";
-            document.getElementById("optionsNumberCard").className = "bg-light card-body";
-            document.getElementById("votesNumberCard").className = "bg-light card-body";
-            document.getElementById("beginCard").className = "bg-light card-body";
-            document.getElementById("finishCard").className = "bg-light card-body";
+            document.getElementById("topCard").className = "card card-shadow-2 bg-white";
+            document.getElementById("optionsNumberCard").className = "card card-shadow-2 bg-white mt-4";
+            document.getElementById("votesNumberCard").className = "card card-shadow-2 bg-white mt-4";
+            document.getElementById("beginCard").className = "card card-shadow-2 bg-white mt-4";
+            document.getElementById("finishCard").className = "card card-shadow-2 bg-white mt-4";
             document.getElementById("congressCard").className = "card card-shadow-2 bg-white mt-4";
             document.getElementById("footerVis").className = "card card-shadow-2 bg-white";
             document.getElementById("daltonicButton").className = "btn btn-sm btn-outline-secondary dropdown-toggle";


### PR DESCRIPTION
Errores corregidos:
- Las esquinas de los contenedores de información perdían el estilo cuando se activaba el modo oscuro

![image](https://user-images.githubusercontent.com/29638526/72122775-6bb2a180-335f-11ea-9669-eeecba2b8af4.png)

- Los iconos de cerrar las ventanas de _Exportar_ y _Compartir_ no estaban adaptados al modo oscuro

![image](https://user-images.githubusercontent.com/29638526/72122784-7705cd00-335f-11ea-9931-90592c43f781.png)

- Se ha añadido una alerta que avisa de que se ha activado/desactivado correctamente el modo oscuro (se elimina automáticamente después de 8 segundos)

![image](https://user-images.githubusercontent.com/29638526/72169903-414cfc80-33d0-11ea-8196-d763517b767f.png)
![image](https://user-images.githubusercontent.com/29638526/72169911-46aa4700-33d0-11ea-977d-1c9dc310ff63.png)


